### PR TITLE
Fixed part of swagger documentation for average order

### DIFF
--- a/src/doc/swagger.json
+++ b/src/doc/swagger.json
@@ -414,7 +414,52 @@
           }
         ]
       }
-    }
+    },
+    "/orders/average": {
+      "get": {
+        "tags": ["Orders"],
+        "summary": "Fetch the average order value for today",
+        "parameters": [
+          {
+            "name": "timeframe",
+            "in": "query",
+            "description": "Timeframe for calculating the average order value. Should be 'today'.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": ["today"],
+              "example": "today"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AverageOrderValue"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request. Please check the request parameters."
+          },
+          "401": {
+            "description": "Unauthorized. Token is invalid or action is not permitted."
+          },
+          "500": {
+            "description": "Internal server error."
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ]
+      }
+    }    
   },
   "components": {
     "schemas": {
@@ -587,6 +632,19 @@
           }
         },
         "required": [ "order_id", "createdAt", "merchant", "customer", "product"]
+      },
+      "AverageOrderValue": {
+        "type": "object",
+        "properties": {
+          "averageSales": {
+            "type": "number",
+            "format": "double",
+            "description": "The average order value for today."
+          }
+        },
+        "example": {
+          "averageSales": 50.45
+        }
       }
     },
     "securitySchemes": {


### PR DESCRIPTION
# Changes proposed

> My earlier PR to get average order sales was reviewed and merged, though the swagger docs didn't align with the code standard and hence was removed. This is an update to that regard and it works as expected
# Check List (Check all the applicable boxes)

:rotating_light:Please review the [style guide for contributing](add link here) and [guidelines for contributing](add link here) to this repository.

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the **main branch** (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

# Screenshot

![average-sales-swagger-doc](https://github.com/hngx-org/zuriportfolio-commander-backend/assets/105442352/77e2113c-b5aa-4c94-b157-63db179381d6)

