### PR TITLE
feat:Add endpoint to retrieve product promotions

### DIFF
--- a/src/doc/swagger.json
+++ b/src/doc/swagger.json
@@ -359,6 +359,86 @@
         }
       }
     },
+      "/discount/promotions": {
+      "get": {
+        "summary": "Retrieve Products with Promotions and number of sales",
+        "tags": ["Discount"],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number for pagination (default: 1)",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "itemsPerPage",
+            "in": "query",
+            "description": "Number of items per page (default: 10)",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of products with associated promotions and tracked promotions",
+            "content":{  "application/json": {
+              "example": [
+                {
+                  "product": {
+                    "id": "product1",
+                    "name": "Product A"
+                  },
+                  "promo": {
+                    "id": "promo1",
+                    "discount_type": "Percentage",
+                    "quantity": 5,
+                    "amount": 10.0,
+                    "valid_from": "2023-10-15T00:00:00Z",
+                    "valid_to": "2023-10-30T00:00:00Z"
+                  },
+                  "sales": 2
+                },
+                {
+                  "product": {
+                    "id": "product2",
+                    "name": "Product B"
+                  },
+                  "promo": {
+                    "id": "promo2",
+                    "discount_type": "Fixed",
+                    "quantity": 10,
+                    "amount": 50.0,
+                    "valid_from": "2023-11-01T00:00:00Z",
+                    "valid_to": "2023-11-15T00:00:00Z"
+               
+                  },
+                  " sales": 1
+                }
+      
+              ]
+            }}
+            
+          },
+          "401": {
+            "description": "Unauthorized access"
+          },
+          "404": {
+            "description": "User not found"
+          }
+        }
+      }
+    }
+,    
     "/shop": {
       "post": {
         "summary": "Create a shop",

--- a/src/routes/discount.route.ts
+++ b/src/routes/discount.route.ts
@@ -23,5 +23,11 @@ export default class DiscountRoute {
       `${this.path}/all`,
       useCatchErrors(this.discountController.getAllDiscount.bind(this.discountController)),
     );
+
+    this.router.get(
+      `${this.path}/promotions`,
+      isAuthenticated,
+      useCatchErrors(this.discountController.getAllPromotionsWithTrackedPromotions.bind(this.discountController))
+    );
   }
 }


### PR DESCRIPTION
Updated the API documentation for the /discount/promotions endpoint to include more detailed examples. Added placeholders for specific product and promotion information within the example response

Added a new API endpoint to retrieve product promotions and the number of sales. The endpoint allows clients to fetch information about products with associated promotions and sales, providing valuable insights into product performance.



# Fixes Issue/Linear Ticket

> This could be an existing issue or a linear ticket
>
> - Github Issue Example: My PR Closes #{ISSUE}
> - Linear Ticket Example: Fixes ID-#{ISSUE}

# Changes proposed

> Talk about the things you did eg. files changes, dependencies installed e.t.c

# Check List (Check all the applicable boxes)

:rotating_light:Please review the [style guide for contributing](add link here) and [guidelines for contributing](add link here) to this repository.

- [V] My code follows the code style of this project.
- [V] This PR does not contain plagiarized content.
- [V] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the **main branch** (left side).
- [V] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

# Screenshots/ Videos

<!-- If the changes are static page changes or UI changes add screenshots -->
<!-- If the changes involve implementing a functionality or working with apis, include a video
detailing how to implement the functionality and the request to the api and responses from the api endpoint-->
<!-- Add all the screenshots/videos which support your changes i.e before your change and after your change -->
