### PR TITLE
Fix update revenue controller

### DIFF
--- a/src/doc/swagger.json
+++ b/src/doc/swagger.json
@@ -685,6 +685,53 @@
           }
         ]
       }
+    },
+    "/revenue/{order_id}": {
+      "patch": {
+        "tags": ["Revenue"],
+        "summary": "Update Revenue",
+        "description": "Update the revenue based on the order's status",
+        "parameters": [
+          {
+            "name": "order_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "string"
+            },
+            "description": "ID of the order to update revenue for"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "example": {
+                  "message": "Revenue updated successfully",
+                  "data": {
+                    "id": 1,
+                    "user_id": "d7955c27-4d61-4cd6-a6bb-e6402151d51f",
+                    "amount": 1500.0
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": "--order/not-found",
+                  "message": "Order not found"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -988,6 +1035,34 @@
         "type": "http",
         "scheme": "bearer",
         "bearerFormat": "JWT"
+      }
+    },
+    "RevenueUpdateResponse": {
+      "type": "object",
+      "properties": {
+        "message": {
+          "type": "string",
+          "description": "A message indicating the result of the operation"
+        },
+        "data": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "integer",
+              "description": "The ID of the updated revenue record"
+            },
+            "user_id": {
+              "type": "string",
+              "format": "uuid",
+              "description": "The user ID for whom the revenue is updated"
+            },
+            "amount": {
+              "type": "number",
+              "format": "float",
+              "description": "The updated revenue amount"
+            }
+          }
+        }
       }
     }
   }

--- a/src/routes/revenue.route.ts
+++ b/src/routes/revenue.route.ts
@@ -14,7 +14,7 @@ export default class RevenueRoute {
 
   initializeRoutes() {
     this.router.patch(
-      `${this.path}/:order_iSd`,
+      `${this.path}/:order_id`,
       useCatchErrors(this.revenueController.updateRevenue.bind(this.revenueController)),
     );
 


### PR DESCRIPTION
# Changes proposed

> This endpoint updates the revenue when an order is completed. The previous controller function did not comply with the code standard for this project. Also, it gave errors owing to changes in the project schema. But all of it has been fixed now and the endpoint is functional. Tests were made using Thunder client on VS code as seen below.

# Check List

:rotating_light:Please review the [style guide for contributing](add link here) and [guidelines for contributing](add link here) to this repository.

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the **main branch** (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

# Screenshots
![not-completed-order](https://github.com/hngx-org/zuriportfolio-commander-backend/assets/105442352/3c0b55e8-f21a-4121-be2d-6a892dfa84ca)
![success update revenue](https://github.com/hngx-org/zuriportfolio-commander-backend/assets/105442352/97e6d258-8e42-4d54-bad5-4d1d198895e0)
