### PR TITLE
Chore: Optimize-search-order-by-productname

### DIFF
--- a/src/doc/swagger.json
+++ b/src/doc/swagger.json
@@ -1179,7 +1179,7 @@
         ]
       }
     },
-    "/orders/search/{name}": {
+    "/order/search/{name}": {
       "get": {
         "tags": [
           "Orders"


### PR DESCRIPTION
# Correcting Swagger Documentation

> Enhances Linear Ticket#COM-24[[Ticket](https://linear.app/zuri-project-backend/issue/COM-24/api-to-search-other-by-product-name)]
> Modifies GitHub PR#95[[PR](https://github.com/hngx-org/zuriportfolio-commander-backend/pull/95)]

# Modifications proposed

This PR corrects the swagger documentation for the /order/search/:name endpoint.

# Check List (Check all the applicable boxes)

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the **main branch** (left side).
- [x] My commit messages styles match our requested structure.
- [x] My code additions will fail neither code linting checks nor unit tests.
- [x] I am only making changes to files I was requested to.


# Screenshots/ Videos
The image below shows the error that prevents the swagger documentation from running properly. On line 1182
![21](https://github.com/hngx-org/zuriportfolio-commander-backend/assets/144495013/8dda92be-6141-48c8-b737-819163b48793)

The image below shows the error corrected on line 1182 i.e order instead of orders
![22](https://github.com/hngx-org/zuriportfolio-commander-backend/assets/144495013/c49ec375-f9c3-4cc4-828e-b56e04427d30)

