### PR TITLE
refactor: getRevenue-and-getAverageOrderValue-controller

### DIFF
--- a/src/doc/swagger.json
+++ b/src/doc/swagger.json
@@ -1307,16 +1307,16 @@
     "/orders/average": {
       "get": {
         "tags": ["Orders"],
-        "summary": "Fetch the average order value for today",
+        "summary": "Fetch the average order value for today || yesterday",
         "parameters": [
           {
             "name": "timeframe",
             "in": "query",
-            "description": "Timeframe for calculating the average order value. Should be 'today'.",
+            "description": "Timeframe for calculating the average order value. Should be 'today' || 'yesterday'.",
             "required": true,
             "schema": {
               "type": "string",
-              "enum": ["today", "week", "month"],
+              "enum": ["today", "yesterday", "week", "month"],
               "example": "today"
             }
           }
@@ -1481,8 +1481,8 @@
     "/revenues": {
       "get": {
         "tags": ["Revenue"],
-        "summary": "Get Revenue for Today",
-        "description": "Get revenue data for today.",
+        "summary": "Get Revenue for Today || yesterday",
+        "description": "Get revenue data for today || yesterday.",
         "parameters": [
           {
             "name": "timeframe",
@@ -1491,7 +1491,7 @@
             "required": true,
             "schema": {
               "type": "string",
-              "enum": ["today"],
+              "enum": ["today", "yesterday", "week"],
               "example": "today"
             }
           }
@@ -1877,7 +1877,7 @@
           "averageOrderValue": {
             "type": "number",
             "format": "double",
-            "description": "The average order value for today."
+            "description": "The average order value for today || yesterday."
           }
         },
         "example": {

--- a/src/routes/revenue.route.ts
+++ b/src/routes/revenue.route.ts
@@ -20,11 +20,10 @@ export default class RevenueRoute {
       useCatchErrors(this.revenueController.updateRevenue.bind(this.revenueController)),
     );
 
-    // Route for /api/revenues?timeframe=today
     this.router.get(
       `${this.path}s`,
       isAuthenticated,
-      useCatchErrors(this.revenueController.getRevenueForToday.bind(this.revenueController)),
+      useCatchErrors(this.revenueController.getRevenue.bind(this.revenueController)),
     );
   }
 }


### PR DESCRIPTION
# Changes proposed

> A frontend dev requested an update in the responses received from the following endpoints:
- revenues?timeframe=yesterday
- revenues?timeframe=today
- orders/average?timeframe=yesterday
shown below. 

This PR rectifies and makes those updates as seen in the screenshots at the bottom of the comment page

![FE request for timeframe=yesterday](https://github.com/hngx-org/zuriportfolio-commander-backend/assets/105442352/724f5ce0-fdca-4a66-93e5-9c5d3c6ca05e)

![FE request for revenueTimeframe=today](https://github.com/hngx-org/zuriportfolio-commander-backend/assets/105442352/9af0054b-d844-4fc1-913a-b853303f9f04)

# Check List 

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the **main branch** (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.

# Screenshots of working routes

![average order for yesterday](https://github.com/hngx-org/zuriportfolio-commander-backend/assets/105442352/6b0a448e-01f8-4de2-9fb3-755ad54caeba)


![revenue for yesterday](https://github.com/hngx-org/zuriportfolio-commander-backend/assets/105442352/01990cb7-d3d7-445b-b5ac-79c214ff5b3f)


![revenue for today](https://github.com/hngx-org/zuriportfolio-commander-backend/assets/105442352/3ee3f901-429c-4d73-9c33-b03c67579aae)

