### PR TITLE
fix: order_item table PK should auto increment

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -103,7 +103,7 @@ model order {
 }
 
 model order_item {
-    id             Int          @id @unique
+    id             Int         @id @default(autoincrement())
     order_id       String
     product_id     String
     merchant_id    String


### PR DESCRIPTION
The table order_item table PK should be auto increment