### PR TITLE
fix: product id to use uuid instead of string

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -124,7 +124,7 @@ model order_item {
 }
 
 model product {
-    id              String         @id @unique
+    id              String         @id @default(uuid())
     user_id         String
     shop_id         String
     category_id     Int


### PR DESCRIPTION
Edit prisma schema to use UUID instead of string